### PR TITLE
fix: 简化时区处理，方便不同时区用户使用，并对 `serialno` 进行说明。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+include/
+lib/
+pyvenv.cfg
+*.DS_Store
+mobiletoken.db

--- a/decrypt-database.py
+++ b/decrypt-database.py
@@ -134,7 +134,7 @@ def wcdb_decrypt_left_pages(raw, page_size, device_salt, password):
 
     return bytes(raw_dec)
 
-g_device_salt = wcdb_generate_device_salt(b'', b'')
+g_device_salt = wcdb_generate_device_salt(b'[serialno]', b'[cpu_serial]')
 
 with open(sys.argv[1], 'rb') as f:
     raw_enc = f.read()

--- a/generate-qqtoken.py
+++ b/generate-qqtoken.py
@@ -2,6 +2,7 @@
 import sys
 from hashlib import sha256
 from datetime import datetime, timezone, timedelta
+import pytz
 
 def GenerateQQTokenSerial(secret: bytes):
     digest = sha256(
@@ -27,9 +28,8 @@ def GenerateQQTokenSerial(secret: bytes):
 
     return '%s-%s-%s-%s' % (serial[0:4], serial[4:8], serial[8:12], serial[12:16])
 
-def GenerateQQTokenCode(currentTimeMillis: int, secret: bytes):
-    tz_beijing = timezone(timedelta(hours = +8))
-    dt_beijing = datetime.fromtimestamp(currentTimeMillis // 1000).replace(tzinfo = tz_beijing)
+def GenerateQQTokenCode(secret: bytes):
+    dt_beijing = datetime.now(pytz.timezone('Asia/Shanghai'))
 
     digest = sha256(secret + b'%d-%02d-%02d %02d:%02d:%02d' % (
         dt_beijing.year,
@@ -62,7 +62,6 @@ def GenerateQQTokenCode(currentTimeMillis: int, secret: bytes):
 
 print(
     GenerateQQTokenCode(
-        int(datetime.now().timestamp() * 1000), 
         bytes.fromhex(sys.argv[1])
     )
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cryptography
+pytz


### PR DESCRIPTION
电脑所在时区非北京时间，修改测试无误。